### PR TITLE
UUID-Based Permit CRUD API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+/permit-api-app/.mvn
+/permit-api-app/logs
+permit-api-app/.envrc

--- a/permit-api-app/.gitattributes
+++ b/permit-api-app/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/permit-api-app/.gitignore
+++ b/permit-api-app/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/permit-api-app/mvnw
+++ b/permit-api-app/mvnw
@@ -1,0 +1,259 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.2
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${0##*/mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/permit-api-app/mvnw.cmd
+++ b/permit-api-app/mvnw.cmd
@@ -1,0 +1,149 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.2
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" (%__MVNW_CMD__% %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace '^.*'+$MVNW_REPO_PATTERN,'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+$MAVEN_HOME_PARENT = "$HOME/.m2/wrapper/dists/$distributionUrlNameMain"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_HOME_PARENT = "$env:MAVEN_USER_HOME/wrapper/dists/$distributionUrlNameMain"
+}
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.MD5]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/permit-api-app/pom.xml
+++ b/permit-api-app/pom.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.3</version>
+        <relativePath /> <!-- lookup parent from repository -->
+    </parent>
+
+    <groupId>com.permittrack</groupId>
+    <artifactId>permit-api</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>permit-api</name>
+    <description>
+        Permit API is the backend component of a modern, iterative Permit Tracking web application tailored for government IT environments. 
+        Built with Spring Boot and Java 17, it provides secure, standards-aligned REST APIs for permit application, status tracking, and administrative review.
+        Designed to work seamlessly with an Angular 19 frontend, this backend supports fast local development, end-to-end testing, and smooth transitions 
+        to cloud deployment. The system uses PostgreSQL via Spring Data JPA and is structured to scale from local demo environments to production-grade 
+        infrastructure on AWS (EC2 or ECS).
+    </description>
+
+    <properties>
+        <java.version>17</java.version>
+        <spring-boot.version>3.5.3</spring-boot.version>
+        <lombok.version>1.18.38</lombok.version>
+        <testcontainers.version>1.19.1</testcontainers.version>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- Core App Dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+
+        <!-- H2 Database (used only for testing) -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Developer Experience -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.3</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Tests.java</include>
+                        <include>**/*Test.java</include>
+                        <include>**/*IT.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/permit-api-app/postman/permit-api.postman_collection.json
+++ b/permit-api-app/postman/permit-api.postman_collection.json
@@ -1,0 +1,128 @@
+{
+    "info": {
+        "_postman_id": "c623b402-36a3-4f68-8d67-983dbbd23e92",
+        "name": "Permit API",
+        "description": "CRUD test collection for the Spring Boot-based Permit API.",
+        "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+    },
+    "item": [
+        {
+            "name": "Create Permit",
+            "request": {
+                "method": "POST",
+                "header": [
+                    {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                    }
+                ],
+                "body": {
+                    "mode": "raw",
+                    "raw": "{\n  \"type\": \"Electrical\",\n  \"status\": \"Pending\",\n  \"applicantName\": \"Jane Doe\"\n}"
+                },
+                "url": {
+                    "raw": "http://localhost:8080/permits",
+                    "protocol": "http",
+                    "host": [
+                        "localhost"
+                    ],
+                    "port": "8080",
+                    "path": [
+                        "permits"
+                    ]
+                }
+            },
+            "response": []
+        },
+        {
+            "name": "Get Permit by ID",
+            "request": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                    "raw": "http://localhost:8080/permits/1",
+                    "protocol": "http",
+                    "host": [
+                        "localhost"
+                    ],
+                    "port": "8080",
+                    "path": [
+                        "permits",
+                        "1"
+                    ]
+                }
+            },
+            "response": []
+        },
+        {
+            "name": "List Permits",
+            "request": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                    "raw": "http://localhost:8080/permits",
+                    "protocol": "http",
+                    "host": [
+                        "localhost"
+                    ],
+                    "port": "8080",
+                    "path": [
+                        "permits"
+                    ]
+                }
+            },
+            "response": []
+        },
+        {
+            "name": "Update Permit",
+            "request": {
+                "method": "PUT",
+                "header": [
+                    {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                    }
+                ],
+                "body": {
+                    "mode": "raw",
+                    "raw": "{\n  \"type\": \"Electrical\",\n  \"status\": \"Approved\",\n  \"applicantName\": \"Jane Doe\"\n}"
+                },
+                "url": {
+                    "raw": "http://localhost:8080/permits/1",
+                    "protocol": "http",
+                    "host": [
+                        "localhost"
+                    ],
+                    "port": "8080",
+                    "path": [
+                        "permits",
+                        "1"
+                    ]
+                }
+            },
+            "response": []
+        },
+        {
+            "name": "Delete Permit",
+            "request": {
+                "method": "DELETE",
+                "header": [],
+                "url": {
+                    "raw": "http://localhost:8080/permits/1",
+                    "protocol": "http",
+                    "host": [
+                        "localhost"
+                    ],
+                    "port": "8080",
+                    "path": [
+                        "permits",
+                        "1"
+                    ]
+                }
+            },
+            "response": []
+        }
+    ]
+}

--- a/permit-api-app/run.sh
+++ b/permit-api-app/run.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# ------------------------------------------------------------------------------
+# Spring Boot runner script for permit-api
+# Uses local Maven Wrapper and env vars for DB credentials.
+# ------------------------------------------------------------------------------
+
+# Fail fast if something breaks
+set -e
+
+# Optional: check that required env vars are set
+: "${DB_USERNAME:?Need to set DB_USERNAME}"
+: "${DB_PASSWORD:?Need to set DB_PASSWORD}"
+
+echo "Starting permit-api with DB user '$DB_USERNAME'..."
+
+# Clean build and run
+./mvnw spring-boot:run -Dspring-boot.run.arguments="--logging.level.root=DEBUG"  2>&1 | tee logs/permit-api.log

--- a/permit-api-app/src/main/java/com/permittrack/permitapi/PermitApiApplication.java
+++ b/permit-api-app/src/main/java/com/permittrack/permitapi/PermitApiApplication.java
@@ -1,0 +1,13 @@
+package com.permittrack.permitapi;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class PermitApiApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(PermitApiApplication.class, args);
+	}
+
+}

--- a/permit-api-app/src/main/java/com/permittrack/permitapi/controller/HealthController.java
+++ b/permit-api-app/src/main/java/com/permittrack/permitapi/controller/HealthController.java
@@ -1,0 +1,12 @@
+package com.permittrack.permitapi.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthController {
+    @GetMapping("/health")
+    public String health() {
+        return "OK";
+    }
+}

--- a/permit-api-app/src/main/java/com/permittrack/permitapi/controller/PermitController.java
+++ b/permit-api-app/src/main/java/com/permittrack/permitapi/controller/PermitController.java
@@ -1,0 +1,65 @@
+package com.permittrack.permitapi.controller;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.permittrack.permitapi.model.Permit;
+import com.permittrack.permitapi.service.PermitService;
+
+/**
+ * REST controller for managing Permit resources.
+ * 
+ * Exposes endpoints to create, retrieve, update, and delete permits.
+ * Communicates with the PermitService layer to perform business logic.
+ */
+@RestController
+@RequestMapping("/permits")
+public class PermitController {
+
+    private final PermitService permitService;
+
+    public PermitController(PermitService permitService) {
+        this.permitService = permitService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Permit> createPermit(@RequestBody Permit permit) {
+        Permit created = permitService.createPermit(permit);
+        return ResponseEntity.ok(created);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Permit> getPermit(@PathVariable UUID id) {
+        return permitService.getPermit(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping
+    public List<Permit> listPermits() {
+        return permitService.listPermits();
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Permit> updatePermit(@PathVariable UUID id, @RequestBody Permit permit) {
+        return permitService.updatePermit(id, permit)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletePermit(@PathVariable UUID id) {
+        boolean deleted = permitService.deletePermit(id);
+        return deleted ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    }
+}

--- a/permit-api-app/src/main/java/com/permittrack/permitapi/model/Permit.java
+++ b/permit-api-app/src/main/java/com/permittrack/permitapi/model/Permit.java
@@ -1,0 +1,49 @@
+package com.permittrack.permitapi.model;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "permits") // plural is the default JPA style; match it to what you want
+public class Permit {
+
+    @Id
+    @GeneratedValue
+    @JdbcTypeCode(SqlTypes.VARCHAR) // H2 does not have type UUID
+    private UUID id;
+
+    private String permitName;
+    private String permitType;
+    private String status;
+    private LocalDateTime submittedDate;
+
+    public Permit(String applicantName, String type, String status, LocalDateTime submittedDate) {
+        this.permitName = applicantName;
+        this.permitType = type;
+        this.status = status;
+        this.submittedDate = submittedDate;
+    }
+
+    @PrePersist
+    public void onCreate() {
+        this.submittedDate = LocalDateTime.now();
+    }
+
+}

--- a/permit-api-app/src/main/java/com/permittrack/permitapi/repository/PermitRepository.java
+++ b/permit-api-app/src/main/java/com/permittrack/permitapi/repository/PermitRepository.java
@@ -1,0 +1,21 @@
+package com.permittrack.permitapi.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.permittrack.permitapi.model.Permit;
+
+/**
+ * Repository interface for performing CRUD operations on Permit entities.
+ * 
+ * Extends JpaRepository to provide standard methods such as save, findById,
+ * findAll, deleteById, and more. This layer abstracts database access logic
+ * and allows easy integration with Spring Data JPA.
+ */
+
+@Repository
+public interface PermitRepository extends JpaRepository<Permit, UUID> {
+
+}

--- a/permit-api-app/src/main/java/com/permittrack/permitapi/service/PermitService.java
+++ b/permit-api-app/src/main/java/com/permittrack/permitapi/service/PermitService.java
@@ -1,0 +1,57 @@
+package com.permittrack.permitapi.service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.permittrack.permitapi.model.Permit;
+import com.permittrack.permitapi.repository.PermitRepository;
+
+/**
+ * Service layer for handling business logic related to Permits.
+ * 
+ * Provides methods for creating, retrieving, updating, and deleting permits.
+ * Acts as a bridge between the controller layer and the data access layer.
+ */
+@Service
+public class PermitService {
+
+    private final PermitRepository permitRepository;
+
+    public PermitService(PermitRepository permitRepository) {
+        this.permitRepository = permitRepository;
+    }
+
+    public Permit createPermit(Permit permit) {
+        return permitRepository.save(permit);
+    }
+
+    public Optional<Permit> getPermit(UUID id) {
+        return permitRepository.findById(id);
+    }
+
+    public List<Permit> listPermits() {
+        return permitRepository.findAll();
+    }
+
+    public Optional<Permit> updatePermit(UUID id, Permit updatedPermit) {
+        return permitRepository.findById(id).map(existing -> {
+            // Update fields here; modify based on your Permit fields
+            existing.setPermitType(updatedPermit.getPermitType());
+            existing.setStatus(updatedPermit.getStatus());
+            existing.setPermitName(updatedPermit.getPermitName());
+            return permitRepository.save(existing);
+        });
+    }
+
+    public boolean deletePermit(UUID id) {
+        if (permitRepository.existsById(id)) {
+            permitRepository.deleteById(id);
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/permit-api-app/src/main/java/com/permittrack/permitapi/support/PermitJsonPath.java
+++ b/permit-api-app/src/main/java/com/permittrack/permitapi/support/PermitJsonPath.java
@@ -1,0 +1,7 @@
+package com.permittrack.permitapi.support;
+
+public class PermitJsonPath {
+    public static final String ID = "$.id";
+    public static final String PERMIT_NAME = "$.permitName";
+    public static final String STATUS = "$.status";
+}

--- a/permit-api-app/src/main/resources/application.yml
+++ b/permit-api-app/src/main/resources/application.yml
@@ -1,0 +1,31 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/permitdb
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
+  application:
+    name: permit-api
+
+server:
+  port: 8080
+
+app:
+  test: hello-world
+
+management:
+  endpoint:
+    health:
+      show-details: never  # hide component-level health info
+  endpoints:
+    web:
+      exposure:
+        include: health, info

--- a/permit-api-app/src/test/java/com/permittrack/permitapi/PermitApiApplicationTests.java
+++ b/permit-api-app/src/test/java/com/permittrack/permitapi/PermitApiApplicationTests.java
@@ -1,0 +1,15 @@
+package com.permittrack.permitapi;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest(classes = PermitApiApplication.class)
+class PermitApiApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/permit-api-app/src/test/java/com/permittrack/permitapi/TestPermitApiApplication.java
+++ b/permit-api-app/src/test/java/com/permittrack/permitapi/TestPermitApiApplication.java
@@ -1,0 +1,41 @@
+package com.permittrack.permitapi;
+
+import org.springframework.boot.SpringApplication;
+
+/**
+ * Entry point for manually running the Permit API with Testcontainers.
+ *
+ * This class launches the application using the standard Spring Boot
+ * configuration
+ * defined in {@link PermitApiApplication}, but overrides the datasource setup
+ * by
+ * injecting {@link TestcontainersConfiguration}, which provides a
+ * PostgreSQLContainer
+ * bean annotated with {@code @ServiceConnection}.
+ *
+ * This enables the application to run against a real PostgreSQL instance in
+ * Docker
+ * (managed by Testcontainers) without changing application.yaml files or
+ * requiring
+ * a separate Spring profile.
+ *
+ * Typical use cases:
+ * - Manually debugging service and database behavior against a real Postgres DB
+ * - Running the backend locally for frontend integration
+ * - Simulating production-like infrastructure during development
+ *
+ * To run:
+ * - Ensure Docker is running
+ * - Execute from your IDE or via shell with the built classpath
+ *
+ * Not intended for use in automated test pipelines — use {@code mvn test} or
+ * integration test classes for that.
+ */
+
+public class TestPermitApiApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.from(PermitApiApplication::main).with(TestcontainersConfiguration.class).run(args);
+	}
+
+}

--- a/permit-api-app/src/test/java/com/permittrack/permitapi/TestcontainersConfiguration.java
+++ b/permit-api-app/src/test/java/com/permittrack/permitapi/TestcontainersConfiguration.java
@@ -1,0 +1,42 @@
+package com.permittrack.permitapi;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Integration test that connects to a real PostgreSQL container using
+ * Testcontainers.
+ *
+ * This test uses Spring Boot's @ServiceConnection (introduced in 3.1+) to
+ * automatically
+ * inject container connection properties (JDBC URL, username, password) into
+ * the
+ * Spring Data JPA configuration. No manual datasource config or YAML overrides
+ * are required.
+ *
+ * Unlike @DataJpaTest, which defaults to H2, this test uses @SpringBootTest to
+ * ensure the
+ * full application context is loaded and the repository is wired against a real
+ * PostgreSQL instance.
+ *
+ * Benefits:
+ * - Simulates real DB behavior (e.g., Postgres constraints, indexing, SQL
+ * dialect)
+ * - Enables high-fidelity integration testing across environments
+ * - Container is isolated, repeatable, and CI-compatible
+ *
+ * Requires Docker to be running.
+ */
+@TestConfiguration(proxyBeanMethods = false)
+class TestcontainersConfiguration {
+
+	@Bean
+	@ServiceConnection
+	PostgreSQLContainer<?> postgresContainer() {
+		return new PostgreSQLContainer<>(DockerImageName.parse("postgres:latest"));
+	}
+
+}

--- a/permit-api-app/src/test/java/com/permittrack/permitapi/controller/PermitControllerIT.java
+++ b/permit-api-app/src/test/java/com/permittrack/permitapi/controller/PermitControllerIT.java
@@ -1,0 +1,119 @@
+package com.permittrack.permitapi.controller;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+// get, post, put, delete, etc.
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.permittrack.permitapi.model.Permit;
+import com.permittrack.permitapi.repository.PermitRepository;
+import com.permittrack.permitapi.support.PermitJsonPath;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test") // Use H2
+public class PermitControllerIT {
+
+    /*
+     * (MockMvc)
+     * ↓
+     * Spring MVC DispatcherServlet
+     * ↓
+     * Controller → Service → Repo → (H2 or Postgres)
+     * 
+     */
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private PermitRepository permitRepository;
+
+    @BeforeEach
+    void clearDb() {
+        permitRepository.deleteAll();
+    }
+
+    private Permit createAndPostSamplePermit(String name) throws Exception {
+        Permit permit = new Permit();
+        permit.setPermitName(name);
+        permit.setStatus("PENDING");
+
+        String json = objectMapper.writeValueAsString(permit);
+        ResultActions response = mockMvc.perform(post("/permits")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json));
+        System.out.println(response.toString());
+        response.andExpect(status().isOk());
+        response.andReturn().getResponse().getContentAsString();
+
+        return objectMapper.readValue(response.andReturn().getResponse().getContentAsString(), Permit.class);
+    }
+
+    @Test
+    public void testCreateAndGetPermit() throws Exception {
+        Permit created = createAndPostSamplePermit("Test Permit");
+        mockMvc.perform(get("/permits/" + created.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath(PermitJsonPath.PERMIT_NAME).value("Test Permit"));
+    }
+
+    @Test
+    public void testListPermits() throws Exception {
+        createAndPostSamplePermit("Permit A");
+        createAndPostSamplePermit("Permit B");
+
+        mockMvc.perform(get("/permits"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(greaterThanOrEqualTo(2)));
+    }
+
+    @Test
+    public void testUpdatePermit() throws Exception {
+        Permit created = createAndPostSamplePermit("Old Name");
+        created.setPermitName("Updated Name");
+
+        mockMvc.perform(put("/permits/" + created.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(created)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath(PermitJsonPath.PERMIT_NAME).value("Updated Name"));
+    }
+
+    @Test
+    public void testDeletePermit() throws Exception {
+        Permit created = createAndPostSamplePermit("To Be Deleted");
+
+        mockMvc.perform(delete("/permits/" + created.getId()))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/permits/" + created.getId()))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void testGetNotFound() throws Exception {
+        mockMvc.perform(get("/permits/" + UUID.randomUUID()))
+                .andExpect(status().isNotFound());
+    }
+
+}

--- a/permit-api-app/src/test/java/com/permittrack/permitapi/repository/PermitRepositoryH2IT.java
+++ b/permit-api-app/src/test/java/com/permittrack/permitapi/repository/PermitRepositoryH2IT.java
@@ -1,0 +1,38 @@
+package com.permittrack.permitapi.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.permittrack.permitapi.model.Permit;
+
+@DataJpaTest
+@ActiveProfiles("test")
+public class PermitRepositoryH2IT {
+
+    @Autowired
+    private PermitRepository permitRepository;
+
+    @Test
+    void testCreateAndFindPermit() {
+        // Arrange
+        Permit permit = new Permit();
+        permit.setPermitName("Jane Doe");
+        permit.setPermitType("Electrical");
+        permit.setStatus("SUBMITTED");
+        permit.setSubmittedDate(LocalDateTime.now());
+
+        // Act
+        Permit saved = permitRepository.save(permit);
+        Permit found = permitRepository.findById(saved.getId()).orElseThrow();
+
+        // Assert
+        assertThat(found.getPermitName()).isEqualTo("Jane Doe");
+        assertThat(found.getPermitType()).isEqualTo("Electrical");
+    }
+}

--- a/permit-api-app/src/test/java/com/permittrack/permitapi/repository/PermitRepositoryPostgresIT.java
+++ b/permit-api-app/src/test/java/com/permittrack/permitapi/repository/PermitRepositoryPostgresIT.java
@@ -1,0 +1,41 @@
+package com.permittrack.permitapi.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.utility.TestcontainersConfiguration;
+
+import com.permittrack.permitapi.model.Permit;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Import(TestcontainersConfiguration.class)
+public class PermitRepositoryPostgresIT {
+
+    @Autowired
+    private PermitRepository permitRepository;
+
+    @Test
+    void testCreateAndFindPermit() {
+        // Arrange
+        Permit permit = new Permit();
+        permit.setPermitName("Jane Doe");
+        permit.setPermitType("Electrical");
+        permit.setStatus("SUBMITTED");
+        permit.setSubmittedDate(LocalDateTime.now());
+
+        // Act
+        Permit saved = permitRepository.save(permit);
+        Permit found = permitRepository.findById(saved.getId()).orElseThrow();
+
+        // Assert
+        assertThat(found.getPermitName()).isEqualTo("Jane Doe");
+        assertThat(found.getPermitType()).isEqualTo("Electrical");
+    }
+}

--- a/permit-api-app/src/test/java/com/permittrack/permitapi/service/PermitServiceTest.java
+++ b/permit-api-app/src/test/java/com/permittrack/permitapi/service/PermitServiceTest.java
@@ -1,0 +1,101 @@
+package com.permittrack.permitapi.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.permittrack.permitapi.model.Permit;
+import com.permittrack.permitapi.repository.PermitRepository;
+
+class PermitServiceTest {
+
+    private PermitRepository permitRepository;
+    private PermitService permitService;
+    private UUID id;
+
+    @BeforeEach
+    void setup() {
+        permitRepository = mock(PermitRepository.class);
+        permitService = new PermitService(permitRepository);
+        id = UUID.randomUUID();
+    }
+
+    @Test
+    void testCreatePermit() {
+        Permit permit = new Permit();
+        permit.setPermitName("Jane Doe");
+
+        when(permitRepository.save(any(Permit.class))).thenReturn(permit);
+
+        Permit result = permitService.createPermit(permit);
+
+        assertThat(result.getPermitName()).isEqualTo("Jane Doe");
+        verify(permitRepository).save(permit);
+    }
+
+    @Test
+    void testGetPermit() {
+        Permit permit = new Permit();
+        permit.setId(id);
+
+        when(permitRepository.findById(id)).thenReturn(Optional.of(permit));
+
+        Optional<Permit> result = permitService.getPermit(id);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(id);
+    }
+
+    @Test
+    void testListPermits() {
+        when(permitRepository.findAll()).thenReturn(List.of(new Permit(), new Permit()));
+
+        List<Permit> permits = permitService.listPermits();
+
+        assertThat(permits).hasSize(2);
+    }
+
+    @Test
+    void testUpdatePermit() {
+        Permit existing = new Permit();
+        existing.setId(id);
+        existing.setPermitName("Old");
+
+        Permit updated = new Permit();
+        updated.setPermitName("New");
+        updated.setPermitType("Electrical");
+        updated.setStatus("SUBMITTED");
+
+        when(permitRepository.findById(id)).thenReturn(Optional.of(existing));
+        when(permitRepository.save(any())).thenReturn(existing);
+
+        Optional<Permit> result = permitService.updatePermit(id, updated);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getPermitName()).isEqualTo("New");
+
+        ArgumentCaptor<Permit> captor = ArgumentCaptor.forClass(Permit.class);
+        verify(permitRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo("SUBMITTED");
+    }
+
+    @Test
+    void testDeletePermit() {
+        when(permitRepository.existsById(id)).thenReturn(true);
+
+        boolean deleted = permitService.deletePermit(id);
+
+        assertThat(deleted).isTrue();
+        verify(permitRepository).deleteById(id);
+    }
+}

--- a/permit-api-app/src/test/resources/application-test.yaml
+++ b/permit-api-app/src/test/resources/application-test.yaml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect

--- a/permit-api-app/verify.sh
+++ b/permit-api-app/verify.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Create logs directory if it doesn't exist
+mkdir -p logs
+
+# Create timestamp
+timestamp=$(date +"%Y-%m-%d_%H-%M-%S")
+
+# Run tests and tee output to timestamped log file
+log_file="logs/test-$timestamp.log"
+echo "Running tests... (log: $log_file)"
+./mvnw clean verify 2>&1 | tee "$log_file"


### PR DESCRIPTION
## 

This PR introduces a fully working, integration-tested Permit API with UUIDs and H2 support.

### Highlights
- CRUD controller with full service/repo layers
- MockMvc tests: create, read, list, update, delete, invalid ID
- JSONPath constants extracted for clarity
- Unit testing for service 
- full controller IT against H2 
- Repo layer tested against both H2 and Postgres container.
- Manual Postman testing complete
- Add a class to perform health checks
