### PR TITLE
add full structured logging and tests to PermitService

### DIFF
--- a/permit-api-app/src/test/java/com/permittrack/permitapi/service/PermitServiceTest.java
+++ b/permit-api-app/src/test/java/com/permittrack/permitapi/service/PermitServiceTest.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 import com.permittrack.permitapi.model.PermitEntity;
 import com.permittrack.permitapi.model.PermitRequestDTO;
@@ -21,6 +22,9 @@ import com.permittrack.permitapi.model.PermitResponseDTO;
 import com.permittrack.permitapi.model.PermitStatus;
 import com.permittrack.permitapi.model.ResourceNotFoundException;
 import com.permittrack.permitapi.repository.PermitRepository;
+import com.permittrack.permitapi.util.InMemoryLogAppender;
+
+import ch.qos.logback.classic.Logger;
 
 class PermitServiceTest {
 
@@ -28,11 +32,19 @@ class PermitServiceTest {
     private PermitService permitService;
     private UUID id;
 
+    private InMemoryLogAppender logAppender;
+    private Logger serviceLogger;
+
     @BeforeEach
     void setup() {
         permitRepository = mock(PermitRepository.class);
         permitService = new PermitService(permitRepository);
         id = UUID.randomUUID();
+        // Setup log capture
+        serviceLogger = (Logger) LoggerFactory.getLogger(PermitService.class);
+        logAppender = new InMemoryLogAppender();
+        logAppender.start();
+        serviceLogger.addAppender(logAppender);
     }
 
     @Test
@@ -50,7 +62,7 @@ class PermitServiceTest {
                 .applicantName("Jane Doe")
                 .permitType("Electrical")
                 .status(PermitStatus.SUBMITTED)
-                .submittedDate(LocalDateTime.now())
+                .submittedDate(LocalDateTime.of(2025, 1, 1, 12, 0)) // fixed date for predictable log
                 .build();
 
         when(permitRepository.save(any(PermitEntity.class))).thenReturn(saved);
@@ -59,17 +71,31 @@ class PermitServiceTest {
 
         assertThat(response.getApplicantName()).isEqualTo("Jane Doe");
         assertThat(response.getPermitType()).isEqualTo("Electrical");
+
+        String logs = logAppender.getEvents().stream()
+                .map(event -> event.getFormattedMessage())
+                .reduce("", (a, b) -> a + "\n" + b);
+
+        assertThat(logs).contains(
+                "Creating new permit request: name=Demo Permit, type=Electrical, status=SUBMITTED, applicant=Jane Doe");
+        assertThat(logs).contains("Permit successfully created: id=" + id);
+        assertThat(logs).contains("Demo Permit");
+        assertThat(logs).contains("Electrical");
+        assertThat(logs).contains("SUBMITTED");
+        assertThat(logs).contains("Jane Doe");
+        assertThat(logs).contains("2025-01-01T12:00");
+
     }
 
     @Test
     void testGetPermit() {
         PermitEntity found = PermitEntity.builder()
                 .id(id)
-                .permitName("Test")
-                .applicantName("Alice")
+                .permitName("Test Permit")
+                .applicantName("Alice Smith")
                 .permitType("Fire")
                 .status(PermitStatus.SUBMITTED)
-                .submittedDate(LocalDateTime.now())
+                .submittedDate(LocalDateTime.of(2025, 1, 2, 10, 30))
                 .build();
 
         when(permitRepository.findById(id)).thenReturn(Optional.of(found));
@@ -77,109 +103,212 @@ class PermitServiceTest {
         PermitResponseDTO response = permitService.getPermit(id);
 
         assertThat(response.getId()).isEqualTo(id);
-        assertThat(response.getApplicantName()).isEqualTo("Alice");
+        assertThat(response.getApplicantName()).isEqualTo("Alice Smith");
+
+        // Assert: Check log contents
+        String logs = logAppender.getEvents().stream()
+                .map(event -> event.getFormattedMessage())
+                .reduce("", (a, b) -> a + "\n" + b);
+
+        // First log: retrieval attempt
+        assertThat(logs).contains("Retrieving permit with ID " + id);
+
+        // Second log: full permit details
+        assertThat(logs).contains("Permit retrieved: id=" + id);
+        assertThat(logs).contains("name=Test Permit");
+        assertThat(logs).contains("type=Fire");
+        assertThat(logs).contains("status=SUBMITTED");
+        assertThat(logs).contains("applicant=Alice Smith");
+        assertThat(logs).contains("submittedDate=2025-01-02T10:30");
     }
 
     @Test
-    void testListPermits() {
+    void testListPermits_logsInfo() {
+        // Arrange: Create 2 permits
         List<PermitEntity> permits = List.of(
                 PermitEntity.builder()
                         .id(UUID.randomUUID())
-                        .permitName("One")
-                        .applicantName("A")
+                        .permitName("Permit One")
+                        .applicantName("Applicant A")
                         .permitType("Electrical")
                         .status(PermitStatus.SUBMITTED)
-                        .submittedDate(LocalDateTime.now())
+                        .submittedDate(LocalDateTime.of(2025, 1, 4, 10, 0))
                         .build(),
                 PermitEntity.builder()
                         .id(UUID.randomUUID())
-                        .permitName("Two")
-                        .applicantName("B")
+                        .permitName("Permit Two")
+                        .applicantName("Applicant B")
                         .permitType("Plumbing")
                         .status(PermitStatus.APPROVED)
-                        .submittedDate(LocalDateTime.now())
+                        .submittedDate(LocalDateTime.of(2025, 1, 5, 14, 30))
                         .build());
 
         when(permitRepository.findAll()).thenReturn(permits);
 
+        // Act
         List<PermitResponseDTO> result = permitService.listPermits();
 
+        // Assert: Check returned DTOs
         assertThat(result).hasSize(2);
-        assertThat(result.get(0).getPermitName()).isEqualTo("One");
+        assertThat(result.get(0).getPermitName()).isEqualTo("Permit One");
+        assertThat(result.get(1).getPermitType()).isEqualTo("Plumbing");
+
+        // Assert: Check logs
+        String logs = logAppender.getEvents().stream()
+                .map(event -> event.getFormattedMessage())
+                .reduce("", (a, b) -> a + "\n" + b);
+
+        // 1. Initial listing log
+        assertThat(logs).contains("Listing all permits");
+
+        // 2. Count log
+        assertThat(logs).contains("Retrieved 2 permits");
     }
 
     @Test
-    void testUpdatePermit() {
+    void testUpdatePermit_logsFullDetails() {
+        // Arrange: Prepare the update DTO
         PermitRequestDTO update = PermitRequestDTO.builder()
-                .permitName("Updated")
+                .permitName("Updated Permit")
                 .applicantName("New Name")
                 .permitType("Mechanical")
                 .status(PermitStatus.REVIEW)
                 .build();
 
+        // Existing entity (what the repo returns before update)
         PermitEntity existing = PermitEntity.builder()
                 .id(id)
-                .permitName("Old")
+                .permitName("Old Permit")
                 .applicantName("Old Name")
                 .permitType("Electrical")
                 .status(PermitStatus.SUBMITTED)
-                .submittedDate(LocalDateTime.now())
+                .submittedDate(LocalDateTime.of(2025, 1, 3, 9, 0))
                 .build();
 
+        // Saved entity (what the repo returns after update)
         PermitEntity saved = PermitEntity.builder()
                 .id(id)
-                .permitName("Updated")
+                .permitName("Updated Permit")
                 .applicantName("New Name")
                 .permitType("Mechanical")
                 .status(PermitStatus.REVIEW)
-                .submittedDate(LocalDateTime.now())
+                .submittedDate(LocalDateTime.of(2025, 1, 3, 9, 0)) // same date for simplicity
                 .build();
 
         when(permitRepository.findById(id)).thenReturn(Optional.of(existing));
-        when(permitRepository.save(any())).thenReturn(saved);
+        when(permitRepository.save(any(PermitEntity.class))).thenReturn(saved);
 
+        // Act
         PermitResponseDTO result = permitService.updatePermit(id, update);
 
+        // Assert: DTO values are correct
         assertThat(result.getPermitType()).isEqualTo("Mechanical");
         assertThat(result.getStatus()).isEqualTo(PermitStatus.REVIEW);
+
+        // Assert: Logs contain both update attempt and success
+        String logs = logAppender.getEvents().stream()
+                .map(event -> event.getFormattedMessage())
+                .reduce("", (a, b) -> a + "\n" + b);
+
+        // 1. Update attempt log
+        assertThat(logs).contains("Updating permit " + id
+                + " with new values: name=Updated Permit, type=Mechanical, status=REVIEW, applicant=New Name");
+
+        // 2. Successful update log
+        assertThat(logs).contains("Permit successfully updated: id=" + id);
+        assertThat(logs).contains("name=Updated Permit");
+        assertThat(logs).contains("type=Mechanical");
+        assertThat(logs).contains("status=REVIEW");
+        assertThat(logs).contains("applicant=New Name");
+        assertThat(logs).contains("submittedDate=2025-01-03T09:00");
     }
 
     @Test
-    void testDeletePermit() {
+    void testDeletePermit_logsFullDetails() {
+        // --- Case 1: Successful delete ---
         when(permitRepository.existsById(id)).thenReturn(true);
 
         boolean result = permitService.deletePermit(id);
 
+        // Assert: Service behavior
         assertThat(result).isTrue();
         verify(permitRepository).deleteById(id);
+
+        // Assert: Logs
+        String logs = logAppender.getEvents().stream()
+                .map(event -> event.getFormattedMessage())
+                .reduce("", (a, b) -> a + "\n" + b);
+
+        // 1. Attempt log
+        assertThat(logs).contains("Attempting to delete permit with ID " + id);
+
+        // 2. Success log
+        assertThat(logs).contains("Permit with ID " + id + " successfully deleted");
     }
 
     @Test
-    void updateThrows404_whenPermitDoesNotExist() {
+    void updateThrows404_whenPermitDoesNotExist_logsWarn() {
         UUID nonexistentId = UUID.randomUUID();
-        PermitRequestDTO request = new PermitRequestDTO();
+        PermitRequestDTO request = PermitRequestDTO.builder()
+                .permitName("Ghost Permit")
+                .applicantName("Nobody")
+                .permitType("Phantom")
+                .status(PermitStatus.REVIEW)
+                .build();
 
+        // Act & Assert: Expect exception
         assertThrows(ResourceNotFoundException.class, () -> {
             permitService.updatePermit(nonexistentId, request);
         });
+
+        // Assert: Check log content
+        String logs = logAppender.getEvents().stream()
+                .map(event -> event.getFormattedMessage())
+                .reduce("", (a, b) -> a + "\n" + b);
+
+        // 1. Attempt log
+        assertThat(logs).contains(
+                "Updating permit " + nonexistentId +
+                        " with new values: name=Ghost Permit, type=Phantom, status=REVIEW, applicant=Nobody");
+
+        // 2. Warning log for missing permit
+        assertThat(logs).contains("Cannot update: permit with ID " + nonexistentId + " not found");
     }
 
     @Test
-    void getThrows404_whenGetPermitDoesNotExist() {
+    void getThrows404_whenGetPermitDoesNotExist_logsWarn() {
         UUID nonexistentId = UUID.randomUUID();
 
+        // Act & Assert: Expect ResourceNotFoundException
         assertThrows(ResourceNotFoundException.class, () -> {
             permitService.getPermit(nonexistentId);
         });
+
+        // Capture logs
+        String logs = logAppender.getEvents().stream()
+                .map(event -> event.getFormattedMessage())
+                .reduce("", (a, b) -> a + "\n" + b);
+
+        // 1. Attempt log
+        assertThat(logs).contains("Retrieving permit with ID " + nonexistentId);
+
+        // 2. Warning log for missing permit
+        assertThat(logs).contains("Permit with ID " + nonexistentId + " not found");
     }
 
     @Test
     void getThrows404_whenDeletePermitDoesNotExist() {
-        UUID nonexistentId = UUID.randomUUID();
 
-        assertThrows(ResourceNotFoundException.class, () -> {
-            permitService.deletePermit(nonexistentId);
-        });
+        when(permitRepository.existsById(id)).thenReturn(false);
+
+        assertThrows(ResourceNotFoundException.class, () -> permitService.deletePermit(id));
+
+        String warnLogs = logAppender.getEvents().stream()
+                .map(event -> event.getFormattedMessage())
+                .reduce("", (a, b) -> a + "\n" + b);
+
+        // Warning log for missing permit
+        assertThat(warnLogs).contains("Cannot delete: permit with ID " + id + " not found");
     }
 
 }

--- a/permit-api-app/src/test/java/com/permittrack/permitapi/util/InMemoryLogAppender.java
+++ b/permit-api-app/src/test/java/com/permittrack/permitapi/util/InMemoryLogAppender.java
@@ -1,0 +1,76 @@
+package com.permittrack.permitapi.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+
+/**
+ * InMemoryLogAppender is a custom Logback appender designed exclusively for
+ * testing.
+ *
+ * <p>
+ * This appender captures all log events that occur during a unit or integration
+ * test
+ * and stores them in memory for later inspection. It allows tests to assert
+ * that
+ * specific log messages were produced, which is critical for applications that
+ * must demonstrate auditability and proper logging practices in government
+ * environments.
+ *
+ * <p>
+ * Key behaviors:
+ * <ul>
+ * <li><b>Test-only usage:</b> This class lives under src/test/java and is never
+ * packaged into production artifacts.</li>
+ * <li><b>Captures structured logs:</b> Each log event (ILoggingEvent) is stored
+ * with level, message,
+ * and optional markers/exceptions, allowing fine-grained assertions.</li>
+ * <li><b>Supports log verification:</b> Tests can check INFO, WARN, and ERROR
+ * messages
+ * to ensure proper logging of business events, failures, and warnings
+ * (e.g., missing permits, payload too large).</li>
+ * <li><b>Reusable across tests:</b> Can be attached to any SLF4J/Logback logger
+ * at runtime
+ * for temporary log capture.</li>
+ * </ul>
+ *
+ * <p>
+ * Typical usage:
+ * 
+ * <pre>
+ * Logger logger = (Logger) LoggerFactory.getLogger(MyService.class);
+ * InMemoryLogAppender appender = new InMemoryLogAppender();
+ * appender.start();
+ * logger.addAppender(appender);
+ *
+ * // Run code that logs events
+ *
+ * assertTrue(appender.getEvents().stream()
+ *         .anyMatch(event -> event.getFormattedMessage().contains("expected log message")));
+ * </pre>
+ *
+ * <p>
+ * After the test, the appender can be stopped or cleared to free resources.
+ * This
+ * class is a crucial tool for verifying compliance with logging requirements
+ * in security-conscious or audit-driven environments.
+ */
+
+public class InMemoryLogAppender extends AppenderBase<ILoggingEvent> {
+    private final List<ILoggingEvent> events = new ArrayList<>();
+
+    @Override
+    protected void append(ILoggingEvent eventObject) {
+        events.add(eventObject);
+    }
+
+    public List<ILoggingEvent> getEvents() {
+        return events;
+    }
+
+    public void clear() {
+        events.clear();
+    }
+}


### PR DESCRIPTION
- Added detailed INFO and WARN logs for all PermitService operations:
  - createPermit: logs name, type, status, applicant, submittedDate
  - getPermit: logs retrieval attempt and full details
  - listPermits: logs listing start and total count
  - updatePermit: logs update attempt and success with full details
  - deletePermit: logs attempt, success, and missing permit warnings

- Implemented InMemoryLogAppender (test-only) to capture logs
- Added log verification to all CRUD unit tests:
  - create, get, list, update, delete
  - includes 404 ResourceNotFound cases with WARN logs
- Ensures audit-ready logging verified in CI for FISMA/government environments