### PR TITLE
docs: Add project documentation and sprint workflow setup

### DIFF
--- a/DEPRICATED_DEBUG_GUIDE.md
+++ b/DEPRICATED_DEBUG_GUIDE.md
@@ -1,0 +1,248 @@
+# Angular Test Debugging Guide
+
+This guide explains how to debug Angular unit tests using VS Code's integrated debugger. Each configuration is designed for specific debugging scenarios in a government-grade development environment.
+
+## 🚀 Quick Setup
+
+**Verify Karma is working**:
+   ```bash
+   ng test
+   ```
+
+## 🎯 Debug Configurations Explained
+
+### 1. Debug Angular Tests (All) - Production Validation
+
+**When to use:**
+- Pre-commit validation
+- CI pipeline testing locally
+- Generating coverage reports for compliance
+- Portfolio demos to stakeholders
+
+**What it does:**
+- Runs **entire test suite** once and exits
+- Generates **code coverage reports** in `coverage/` folder
+- Uses **headless Chrome** for speed and CI compatibility
+- **No watch mode** - perfect for scripted environments
+
+**How to use:**
+1. Set breakpoints in any test file (click red dot in gutter)
+2. Press `F5` → Select "Debug Angular Tests (All)"
+3. Tests run once, coverage report generated
+4. Execution pauses at breakpoints for inspection
+
+**Pro tip**: Use this before pushing to ensure your tests pass and meet coverage requirements.
+
+---
+
+### 2. Debug Angular Tests (Watch Mode) - TDD Development
+
+**When to use:**
+- Test-Driven Development workflow
+- Active feature development
+- Continuous feedback during coding
+
+**What it does:**
+- Runs tests and **stays running**
+- **Auto-reruns tests** when you save files
+- **Immediate feedback** on code changes
+- Headless execution for performance
+
+**How to use:**
+1. Set breakpoints in test files
+2. Press `F5` → Select "Debug Angular Tests (Watch Mode)"
+3. **Make changes** to service or test files
+4. **Save file** → tests automatically re-run
+5. Execution pauses at breakpoints on each run
+
+**TDD Workflow:**
+```
+1. Write failing test → Save → See red
+2. Implement feature → Save → See green
+3. Refactor → Save → Ensure still green
+```
+
+---
+
+### 3. Debug Specific Test File - Focused Testing
+
+**When to use:**
+- Debugging a single service or component
+- Isolating test failures
+- Working on specific functionality
+
+**What it does:**
+- Runs **only tests matching the pattern** (currently `**/*permit.service.spec.ts`)
+- **Single run** with focused output
+- **Faster execution** by skipping unrelated tests
+
+**How to customize:**
+```json
+// In launch.json, modify the --include pattern:
+"--include", "**/*component.spec.ts"     // All component tests
+"--include", "**/services/**/*.spec.ts"  // All service tests  
+"--include", "**/*permit*.spec.ts"       // All permit-related tests
+```
+
+**How to use:**
+1. **Modify the pattern** if needed
+2. Set breakpoints in your target test file
+3. Press `F5` → Select "Debug Specific Test File"
+4. Only matching tests execute
+
+---
+
+### 4. Debug Tests with Chrome DevTools - Visual Debugging
+
+**When to use:**
+- Debugging complex DOM interactions
+- Inspecting HTTP requests/responses
+- Visual component testing
+- Network debugging
+
+**What it does:**
+- Opens **real Chrome browser** (not headless)
+- **Watch mode** keeps browser open
+- Access to **full Chrome DevTools** (F12)
+- **Visual inspection** of test results
+
+**Chrome DevTools Features:**
+- **Sources tab**: Set breakpoints, step through code
+- **Network tab**: Inspect HTTP requests/responses
+- **Console tab**: View logs, execute code
+- **Elements tab**: Inspect DOM changes during tests
+
+**How to use:**
+1. Set breakpoints in VS Code
+2. Press `F5` → Select "Debug Tests with Chrome DevTools"  
+3. Chrome opens and runs tests
+4. **Press F12** in Chrome for DevTools
+5. **Use both VS Code AND Chrome** debugging simultaneously
+
+**Pro tip**: Perfect for debugging HttpClientTestingModule requests and component rendering.
+
+---
+
+### 5. Debug Single Test (Manual) - Granular Control
+
+**When to use:**
+- Debugging one specific test case
+- Karma configuration troubleshooting
+- Custom test scenarios
+
+**What it does:**
+- **Direct Karma execution** (bypasses Angular CLI)
+- Uses **grep pattern** to run specific tests
+- **Maximum control** over test execution
+
+**How to customize:**
+```json
+// In launch.json, modify the --grep pattern:
+"--grep=should be created"           // Exact test description
+"--grep=should.*create"             // Pattern matching
+"--grep=PermitService.*fetch"       // Service-specific tests
+```
+
+**How to use:**
+1. **Find the exact test description** you want to debug
+2. **Update the --grep pattern** in launch.json
+3. Set breakpoints
+4. Press `F5` → Select "Debug Single Test (Manual)"
+5. Only that specific test runs
+
+---
+
+## 🔧 Debugging Workflow
+
+### Setting Breakpoints
+```typescript
+describe('PermitService', () => {
+  it('should fetch all permits', () => {
+    // Click here in gutter → Red dot appears
+    service.requestAllPermits.subscribe((permits) => {
+      expect(permits.length).toBe(2); // ← Set breakpoint here
+      expect(permits).toEqual(mockPermits);
+    });
+  });
+});
+```
+
+### Debug Controls
+- **F5**: Continue execution
+- **F10**: Step Over (next line in current function)
+- **F11**: Step Into (enter function calls)
+- **Shift+F11**: Step Out (exit current function)
+- **Ctrl+Shift+F5**: Restart debugger
+
+### Variable Inspection
+- **Hover**: Mouse over variables to see current values
+- **Variables panel**: View all local/global variables
+- **Watch panel**: Monitor specific expressions
+- **Debug console**: Execute code in current context
+
+## 📊 Coverage Reports
+
+When using "Debug Angular Tests (All)", coverage reports are generated in:
+```
+coverage/
+├── lcov-report/index.html  ← Open this in browser
+├── lcov.info               ← For CI tools
+└── clover.xml             ← For Jenkins/SonarQube
+```
+
+## 🚨 Troubleshooting
+
+### Tests Not Starting
+```bash
+# Clear node_modules and reinstall
+rm -rf node_modules package-lock.json
+npm install
+```
+
+### Breakpoints Not Hit
+- Ensure you're using TypeScript source maps
+- Check that `sourceMap: true` in `tsconfig.json`
+- Restart VS Code after config changes
+
+### Chrome Won't Open
+```bash
+# Install Chrome if missing
+# Ubuntu: sudo apt install google-chrome-stable
+# macOS: brew install --cask google-chrome
+```
+
+### Specific Test Not Running
+- Verify test description matches `--grep` pattern exactly
+- Check for typos in test names
+- Ensure test file is included in `tsconfig.spec.json`
+
+## 💡 Government Development Tips
+
+### Security Testing
+Use "Debug Tests with Chrome DevTools" to:
+- Inspect request headers for security tokens
+- Verify CORS handling
+- Check for data sanitization
+
+### CI/CD Integration
+"Debug Angular Tests (All)" configuration matches:
+- Jenkins pipeline execution
+- GitHub Actions workflows
+- Government deployment standards
+
+### Code Quality Assurance
+- Use coverage reports for compliance requirements
+- Debug failing tests before committing
+- Validate error handling paths
+
+---
+
+## 🎯 Recommended Workflow
+
+1. **Start with Watch Mode** for general development
+2. **Switch to Specific File** when focusing on one component
+3. **Use Chrome DevTools** for complex debugging scenarios
+4. **Run All Tests** before committing changes
+5. **Use Manual/Grep** for troubleshooting specific test failures
+
+This debugging setup ensures your Angular application meets government-grade quality standards while maintaining developer productivity.

--- a/core-context-ai-description.md
+++ b/core-context-ai-description.md
@@ -1,0 +1,53 @@
+# Permit Tracking App - Sprint Context for Claude
+
+## 📊 Current Status
+- **Frontend**: Angular 19 (95% complete) with Bootstrap UI + Cypress E2E tests ✅
+- **Backend**: Spring Boot 3.x (partially complete, needs Sprint 1-3 modifications) 🔄
+- **Integration**: Components work independently, requires CORS + API alignment
+- **Project Board**: https://github.com/users/lperthel/projects/1
+
+## 🏃‍♂️ Current Sprint 1: First Demoable API
+**Goal**: Ship GET /api/permits endpoint with integration tests + Swagger UI
+
+**Active Issues**:
+- **Issue #1**: Project Bootstrap & Core Structure [CURRENT FOCUS]
+- **Issue #2**: Database Schema & Flyway Setup  
+- **Issue #3**: Permit Entity & Repository Layer
+- **Issue #4**: GET /api/permits Endpoint with DTOs
+- **Issue #17**: Swagger/OpenAPI Documentation Setup
+
+**Deliverable**: Working GET /api/permits via Postman + interactive Swagger UI
+
+## 🛠️ Tech Stack
+**Frontend**: Angular 19, TypeScript, Bootstrap 5, Cypress  
+**Backend**: Java 17, Spring Boot 3.x, PostgreSQL, JPA, Flyway  
+**Testing**: Integration tests required per endpoint, JaCoCo coverage >90%  
+**Docs**: Swagger UI, Postman collections  
+**Future**: AWS ECS + RDS deployment
+
+## 🏛️ Government-Ready Standards
+- **Security-First**: Input validation, CORS, no sensitive data in logs
+- **FISMA-Minded**: Stable tech stack, comprehensive testing, audit trails
+- **DTO Pattern**: Never expose entities directly, always use Data Transfer Objects
+- **Error Handling**: @ControllerAdvice global exceptions, generic error messages
+- **Integration Testing**: Every API endpoint requires working integration test
+
+## 🎯 What I Need From You
+- **Technical guidance** on Spring Boot architecture and government patterns
+- **Code review** for enterprise/government compliance standards  
+- **Push me to ship** - call out overthinking, focus on concrete next steps
+- **Sprint-focused advice** - help me complete Issue #1, then move to #2, etc.
+- **Challenge decisions** when I'm choosing suboptimal approaches
+
+## 🔄 Development Approach
+- **Demo-driven**: Every sprint ends with something testable via Postman/browser
+- **Local-first**: Get working locally before any cloud deployment
+- **Small iterations**: Complete issues #1-4 before moving to Sprint 2
+- **Integration testing**: Build fails if any test fails (Surefire + Failsafe)
+
+## 📋 Current Sprint Workflow
+**Sprint 1 Progress**: Working through Issues #1-4 sequentially  
+**Next Sprint**: Sprint 2 (POST/PUT/DELETE endpoints) after Sprint 1 demo complete  
+**Board Updates**: I'll tell you when issues move between columns or get completed
+
+> **Reference**: Full project timeline and detailed requirements in separate documentation. This core context focuses on current Sprint 1 work.

--- a/definition-of-done-checklist.md
+++ b/definition-of-done-checklist.md
@@ -1,0 +1,174 @@
+# Definition of Done - All Issues
+
+This checklist ensures consistent quality and government-ready standards across all development work. Every issue must meet these criteria before being marked "Done" and moved to "🚀 Sprint Complete".
+
+---
+
+## 🧪 Testing Requirements
+
+### **Test Coverage**
+- [ ] Test coverage >90% for new features and modifications
+- [ ] Unit tests for all service layer methods
+- [ ] Integration test for each new API endpoint
+- [ ] All tests pass locally before PR submission
+- [ ] No test files skipped or ignored without documented reason
+
+### **API Endpoint Testing**
+- [ ] Integration test covers complete HTTP request/response flow
+- [ ] Test cases include success scenarios (200, 201, 204)
+- [ ] Test cases include error scenarios (400, 404, 409, etc.)
+- [ ] Edge cases and boundary conditions tested
+- [ ] Business rule validation tested where applicable
+
+### **Frontend Testing**
+- [ ] Component unit tests for new Angular components
+- [ ] E2E tests updated for new user workflows
+- [ ] Cross-browser compatibility verified (Chrome, Firefox, Edge)
+- [ ] Accessibility testing completed (axe-core, manual keyboard navigation)
+
+---
+
+## 💻 Code Quality
+
+### **Government-Ready Standards**
+- [ ] All hardcoded strings extracted to `final String` constants
+- [ ] No sensitive data logged (only IDs, statuses, non-PII)
+- [ ] Input validation implemented with `@Valid` annotations
+- [ ] Error messages are generic (no sensitive information exposure)
+- [ ] DTO pattern enforced (never expose entities directly)
+
+### **Security & Validation**
+- [ ] All user inputs validated server-side
+- [ ] SQL injection prevention (parameterized queries)
+- [ ] XSS prevention through proper input sanitization
+- [ ] CORS configuration reviewed and appropriate
+- [ ] Authentication/authorization patterns followed (when applicable)
+
+### **Error Handling**
+- [ ] `@ControllerAdvice` used for global exception handling
+- [ ] Meaningful HTTP status codes returned
+- [ ] Consistent error response format
+- [ ] Manual error responses documented with reasoning
+- [ ] Graceful degradation for non-critical failures
+
+---
+
+## 📖 Documentation
+
+### **API Documentation**
+- [ ] Swagger/OpenAPI annotations added for new endpoints
+- [ ] Request/response schemas documented with examples
+- [ ] HTTP status codes documented for each endpoint
+- [ ] Business rules and validation constraints documented
+- [ ] Error response formats documented
+
+### **Code Documentation**
+- [ ] Class-level comments explain role and interactions
+- [ ] Public method comments include purpose, inputs/outputs, exceptions
+- [ ] Inline comments for complex business logic
+- [ ] Security-related code thoroughly commented
+- [ ] Non-obvious algorithms or patterns explained
+
+### **Project Documentation**
+- [ ] README updated if new setup steps or commands added
+- [ ] Environment variables documented if new config added
+- [ ] Architecture decisions recorded for significant changes
+- [ ] API breaking changes noted for frontend integration
+
+---
+
+## 🔧 Integration Requirements
+
+### **API Integration**
+- [ ] Postman collection updated with new/modified endpoints
+- [ ] CORS configuration supports frontend integration
+- [ ] Environment-specific configuration externalized
+- [ ] Database migrations tested and documented
+- [ ] Backward compatibility maintained (or breaking changes documented)
+
+### **Frontend-Backend Integration**
+- [ ] Angular services updated to use new API endpoints
+- [ ] Error handling implemented for API failures
+- [ ] Loading states provided for better user experience
+- [ ] Mock data updated to match real API responses
+- [ ] E2E tests work with integrated backend
+
+---
+
+## 🏗️ Build & Deployment
+
+### **Build Requirements**
+- [ ] Maven build succeeds (`./mvnw clean verify`)
+- [ ] No compilation warnings or errors
+- [ ] All dependencies properly declared in `pom.xml`
+- [ ] Build fails if any test fails (Surefire + Failsafe configured)
+- [ ] JaCoCo coverage reports generated successfully
+
+### **Environment Compatibility**
+- [ ] Application starts successfully in development profile
+- [ ] Health check endpoint returns 200 OK
+- [ ] Database migrations run successfully on clean database
+- [ ] Environment variables properly externalized
+- [ ] No hardcoded environment-specific values
+
+---
+
+## 📋 Sprint-Specific Requirements
+
+### **Sprint Demo Readiness**
+- [ ] Feature is demonstrable via Postman or browser
+- [ ] Demo scenarios documented and tested
+- [ ] Feature integrates properly with existing functionality
+- [ ] No critical bugs that prevent demo
+- [ ] Stakeholder-facing documentation updated
+
+### **Government Compliance**
+- [ ] Code follows FISMA-minded security practices
+- [ ] Audit trail considerations implemented where applicable
+- [ ] Data validation follows government standards
+- [ ] Error handling meets enterprise requirements
+- [ ] Performance considerations appropriate for government workloads
+
+---
+
+## ✅ Issue Completion Checklist
+
+Before moving any issue to "Done":
+
+1. **Developer Self-Review**
+   - [ ] All acceptance criteria met
+   - [ ] All items in this Definition of Done completed
+   - [ ] Code reviewed for government compliance standards
+   - [ ] Local testing completed successfully
+
+2. **Code Review** (if applicable)
+   - [ ] Peer review completed for security-sensitive code
+   - [ ] Architectural decisions validated
+   - [ ] Government standards compliance verified
+
+3. **Integration Validation**
+   - [ ] Feature works with existing system components
+   - [ ] No regressions introduced to existing functionality
+   - [ ] API contracts maintained or properly versioned
+
+4. **Documentation Complete**
+   - [ ] All documentation requirements above satisfied
+   - [ ] Issue description updated with final implementation notes
+   - [ ] Next issue dependencies identified and documented
+
+---
+
+## 🎯 Quality Gates
+
+**No issue can be marked "Done" unless:**
+- ✅ All testing requirements met
+- ✅ All code quality standards met  
+- ✅ All documentation requirements met
+- ✅ All integration requirements met
+- ✅ Sprint demo functionality verified
+
+**Remember**: Government-ready software requires higher standards than typical commercial development. These requirements ensure we maintain that quality bar consistently across all sprints.
+
+---
+
+> **Note**: This Definition of Done may be updated based on lessons learned during sprint execution. Any changes should be documented and communicated to the development team.

--- a/ng-cli-and-node-version.txt
+++ b/ng-cli-and-node-version.txt
@@ -1,0 +1,23 @@
+Angular CLI: 19.2.15
+Node: 22.12.0
+Package Manager: npm 10.9.0
+OS: darwin arm64
+
+Angular: 19.2.14
+... animations, common, compiler, compiler-cli, core, forms
+... localize, platform-browser, platform-browser-dynamic, router
+
+Package                         Version
+---------------------------------------------------------
+@angular-devkit/architect       0.1902.15
+@angular-devkit/build-angular   19.2.15
+@angular-devkit/core            19.2.15
+@angular-devkit/schematics      19.2.15
+@angular/build                  19.2.15
+@angular/cdk                    19.2.19
+@angular/cli                    19.2.15
+@angular/material               19.2.19
+@schematics/angular             19.2.15
+rxjs                            7.8.2
+typescript                      5.6.3
+zone.js                         0.15.1

--- a/sprint-workflow-documentation.md
+++ b/sprint-workflow-documentation.md
@@ -1,0 +1,209 @@
+# Sprint-Based AI Workflow Documentation
+
+## 🎯 Workflow Overview
+
+This document defines the workflow for managing AI conversations and project updates across sprint cycles for the Permit Tracking Application development.
+
+**Core Principle**: One AI conversation per sprint to maintain technical context while enabling focused sprint execution.
+
+---
+
+## 📋 Conversation Structure
+
+### **One Conversation Per Sprint**
+- **Sprint 1**: Issues #1-4 + #17 (First Demoable API)
+- **Sprint 2**: Issues #5-7 + #18-19 (Complete CRUD Operations)  
+- **Sprint 3**: Issues #8-9 (Frontend-Backend Integration)
+- **Sprint 4**: Issues #15-16 (UI Polish & Compliance)
+
+### **Why Sprint-Based vs. Issue-Based**
+✅ **Technical continuity** - architectural decisions carry forward within sprint  
+✅ **Integration context** - issues within sprint are highly interconnected  
+✅ **Sprint demo preparation** - full sprint context needed for deliverable  
+✅ **Reduced context switching** - 4 conversations vs. 16+ conversations  
+
+---
+
+## 🔄 Between Sprint Conversations Workflow
+
+### **End of Sprint Checklist**
+
+#### 1. Update GitHub Project Board
+- [ ] Move all completed issues to "🚀 Sprint Complete" column
+- [ ] Move any incomplete issues to next sprint or backlog
+- [ ] Update issue status and add completion notes
+- [ ] Close completed milestone in GitHub
+
+#### 2. Update Project README
+- [ ] Update "Current Status" section with sprint completion
+- [ ] Mark completed phase/sprint as ✅ 
+- [ ] Update "Project Completion Timeline" progress
+- [ ] Add any new learnings or architectural decisions
+
+#### 3. Create Sprint Summary Document
+Save in project as `sprint-X-summary.md`:
+```markdown
+# Sprint X Summary
+
+## Completed Issues
+- Issue #X: [Title] - [Key learnings/decisions]
+- Issue #Y: [Title] - [Key learnings/decisions]
+
+## Sprint Demo Results
+- **Deliverable**: [What was demoed]
+- **Stakeholder Feedback**: [Any feedback received]
+- **Technical Achievements**: [Key milestones reached]
+
+## Blockers/Challenges Encountered
+- [Technical challenge] - [How resolved]
+- [Architectural decision] - [Rationale]
+
+## Lessons Learned
+- [Key insight 1]
+- [Key insight 2]
+
+## Handoff to Next Sprint
+- **Ready for Next Sprint**: [Issues ready to start]
+- **Dependencies**: [Any blockers for next sprint]
+- **Technical Debt**: [Items to address later]
+```
+
+#### 4. Prepare Next Sprint Context
+Create brief status for next AI conversation:
+```markdown
+# Sprint X+1 Status Update
+
+## Previous Sprint Results
+- **Completed**: Sprint X ✅ - [brief description of deliverable]
+- **Demo Status**: [working/needs fixes/blocked]
+- **Technical Stack Status**: [any new dependencies/changes]
+
+## Current Sprint Goals
+- **Sprint X+1**: [sprint name and goal]
+- **Priority Issues**: [list in order]
+- **Expected Deliverable**: [what should be demoable at end]
+
+## Project Board Status
+- **Backlog**: [# issues]
+- **Current Sprint**: [# issues]
+- **In Progress**: [current work]
+- **Blockers**: [any impediments]
+
+## Technical Context Needed
+- [Any architectural decisions from previous sprint]
+- [New dependencies or configuration changes]
+- [Integration points or API changes]
+```
+
+---
+
+## 🚀 Starting New Sprint Conversation
+
+### **Conversation Initialization Template**
+
+**Subject/Title**: `Sprint X: [Sprint Name] - [Brief Goal]`
+
+**Opening Message**:
+```
+Starting Sprint X: [Sprint Name]
+
+[Paste sprint status update from preparation above]
+
+## AI Context Needed
+- Sprint focus: [primary goals]
+- Technical decisions needed: [architectural choices]
+- Code review areas: [government compliance, security, etc.]
+- Demo preparation: [what needs to be working by sprint end]
+
+Ready to dive into Issue #X: [First Issue Name]?
+```
+
+### **Include Core Project Context**
+Always include the shortened core context (381 words) at start of sprint conversation for AI reference.
+
+---
+
+## 📊 Project Maintenance Schedule
+
+### **Weekly During Sprint**
+- [ ] Update project board as issues move through workflow
+- [ ] Commit code with clear issue references (`git commit -m "Issue #X: implementation description"`)
+- [ ] Update issue descriptions with progress notes
+
+### **End of Each Sprint**
+- [ ] Complete "End of Sprint Checklist" above
+- [ ] Create demo video/screenshots for portfolio
+- [ ] Update stakeholder documentation if needed
+- [ ] Prepare next sprint conversation context
+
+### **Monthly Project Health Check**
+- [ ] Review overall timeline and adjust if needed
+- [ ] Update comprehensive project documentation
+- [ ] Assess if workflow changes needed
+- [ ] Plan upcoming phase priorities
+
+---
+
+## 🛠️ Tools and Resources
+
+### **GitHub Project Management**
+- **Project Board**: https://github.com/users/lperthel/projects/1
+- **Milestones**: One per sprint with due dates
+- **Labels**: Sprint + phase for organization
+- **Issues**: Detailed acceptance criteria and definition of done
+
+### **Documentation Locations**
+- **Core AI Context**: `/docs/ai-context-core.md` (381 words, use for each sprint)
+- **Sprint Summaries**: `/docs/sprint-summaries/` (one file per sprint)
+- **Architecture Decisions**: `/docs/architecture-decisions.md` (major technical choices)
+
+### **Demo and Portfolio Materials**
+- **Screenshots**: `/docs/demo-materials/sprint-X-screenshots/`
+- **Demo Videos**: `/docs/demo-materials/sprint-X-videos/`
+- **Postman Collections**: `/docs/api-testing/` (export after each sprint)
+
+---
+
+## ⚠️ Common Pitfalls to Avoid
+
+### **Context Loss Between Sprints**
+- **Solution**: Always include architectural decisions in sprint summary
+- **Solution**: Reference previous sprint technical choices in new conversation
+
+### **Scope Creep Within Sprint**
+- **Solution**: Stick to planned sprint issues, add new ideas to backlog
+- **Solution**: Have AI challenge scope additions during sprint
+
+### **Demo Preparation Gaps**
+- **Solution**: Ensure every sprint ends with working, testable deliverable
+- **Solution**: Test demo scenarios before ending sprint conversation
+
+### **Documentation Lag**
+- **Solution**: Update README and project board immediately after sprint completion
+- **Solution**: Create sprint summary while context is fresh
+
+---
+
+## 🎯 Success Metrics
+
+### **Workflow Effectiveness**
+- [ ] Each sprint conversation stays focused on sprint goals
+- [ ] Technical decisions carry forward appropriately between sprints
+- [ ] Project documentation stays current and accurate
+- [ ] Demo deliverables are consistently achieved
+
+### **Project Management Quality**
+- [ ] GitHub project board reflects actual development status
+- [ ] Sprint summaries provide clear progress narrative
+- [ ] Stakeholders can understand project status from documentation
+- [ ] No major scope or timeline surprises between sprints
+
+### **AI Collaboration Quality**
+- [ ] AI conversations stay productive and technically focused
+- [ ] Architectural guidance is consistent across sprints
+- [ ] Code review and standards enforcement remains effective
+- [ ] Sprint goals are achieved with AI guidance
+
+---
+
+> **Note**: This workflow documentation should be updated based on experience and evolving project needs. Treat it as a living document that improves with each sprint cycle.


### PR DESCRIPTION
- Add sprint-based development workflow documentation (/docs/sprint-workflow.md)
- Create Definition of Done checklist for government-ready standards (/docs/definition-of-done.md)
- Update README with comprehensive setup instructions and current status
- Add sprint workflow section to README
- Remove Project-Description.md duplication (refer to project board instead)
- Set up GitHub project board documentation structure
- Establish documentation foundation for Sprint 1-4 execution

Closes #35 